### PR TITLE
Add requests==2.11.1 to requirements file

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,2 +1,3 @@
 suds-jurko==0.6
 httplib2==0.9.1
+requests==2.11.1


### PR DESCRIPTION
## What 
Formally add requests==2.11.1 to the list of requirements. 

## Why
As it stands, importing this library (from the commit before this) fails due to the lack of this dependency.

```python
In [1]: import zuora
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-6efe98924b0a> in <module>()
----> 1 import zuora

/Users/coonce/python-zuora/zuora/__init__.py in <module>()
----> 1 from client import (Zuora, convert_camel, zuora_serialize,
      2                     zuora_serialize_list, ZuoraException,
      3                     DoesNotExist, MissingRequired)
      4 from rest_client import RestClient

/Users/coonce/python-zuora/zuora/client.py in <module>()
     31 from suds.sax.text import Text
     32
---> 33 from rest_client import RestClient
     34
     35 log = logging.getLogger(__name__)

/Users/coonce/python-zuora/zuora/rest_client.py in <module>()
----> 1 import requests
      2 from rest_wrapper import (AccountManager, CatalogManager, PaymentMethodManager,
      3                           SubscriptionManager, TransactionManager,
      4                           UsageManager)
      5

ImportError: No module named requests
```

