### PR TITLE
Add Amendment API Interface

### DIFF
--- a/zuora/rest_client.py
+++ b/zuora/rest_client.py
@@ -1,9 +1,8 @@
 import requests
-from rest_wrapper import (AccountManager, CatalogManager, PaymentMethodManager,
-                          SubscriptionManager, TransactionManager,
-                          UsageManager)
+from rest_wrapper import (AccountManager, AmendmentManager, CatalogManager,
+                          PaymentMethodManager, SubscriptionManager,
+                          TransactionManager, UsageManager)
 
-requests.packages.urllib3.disable_warnings()
 ## This file contains some parameters that will need to be changed to work in different tenants:
 ## REQUIRED PARAMS:
 ## username: change to an API user that has REST write capabilities
@@ -37,6 +36,7 @@ class RestClient(object):
     def __init__(self, zuora_settings):
         self.zuora_config = ZuoraConfig(zuora_settings)
         self.account = AccountManager(self.zuora_config)
+        self.amendment = AmendmentManager(self.zuora_config)
         self.catalog = CatalogManager(self.zuora_config)
         self.payment_method = PaymentMethodManager(self.zuora_config)
         self.subscription = SubscriptionManager(self.zuora_config)

--- a/zuora/rest_wrapper/__init__.py
+++ b/zuora/rest_wrapper/__init__.py
@@ -1,4 +1,5 @@
 from account_manager import AccountManager
+from amendment_manager import AmendmentManager
 from catalog_manager import CatalogManager
 from payment_method_manager import PaymentMethodManager
 from subscription_manager import SubscriptionManager

--- a/zuora/rest_wrapper/amendment_manager.py
+++ b/zuora/rest_wrapper/amendment_manager.py
@@ -1,0 +1,42 @@
+import logging
+
+import requests
+
+from request_base import RequestBase, rest_client_reconnect
+
+
+# This hack suppresses a `urllib3.InsecureRequestWarning` warning; This noisy
+# warning is only introduced here. Instead of printing this out on each request
+# to Zuora's amendment endpoint. See this note for details: https://urllib3.readthedocs.io/en/latest/security.html
+logging.captureWarnings(True)
+
+
+class AmendmentManager(RequestBase):
+    """
+    Request class that allows users to fetch Amendment data from Zuora.
+    """
+    @rest_client_reconnect
+    def get_amendment_by_subscription_id(self, subscription_id, page_size=20):
+        """
+        Returns a dictionary of Amendment data given a specific Subscription ID (or key).
+        References:
+            * https://knowledgecenter.zuora.com/DC_Developers/REST_API/B_REST_API_reference/Amendments/Get_Amendments_By_Subscription_Id
+        Usage:
+            * zuora_client.rest_client.amendment.get_amendment_by_subscription_id('2c92a0fd57e07d490157e3889ff837f4')
+            * zuora_client.rest_client.amendment.get_amendment_by_subscription_id('A-S00001503')
+        Notes:
+            The Zuora API only returns a single Amendment for each version of
+            a subscription.
+        """
+        full_url = '{}amendments/subscriptions/{}'.format(
+            self.zuora_config.base_url,
+            subscription_id
+        )
+
+        response = requests.get(
+            full_url,
+            params={'pageSize': page_size},
+            headers=self.zuora_config.headers,
+            verify=False
+        )
+        return self.get_json(response)


### PR DESCRIPTION
## What

Adds an interface that provides access to [Zuora's Amendment API](https://knowledgecenter.zuora.com/DC_Developers/REST_API/B_REST_API_reference/Amendments/Get_Amendments_By_Subscription_Id).

Currently only provides a developer access to the the most recent `Amendment` (if one exists) for a given subscription id.
## Usage

``` python
import zuora

zuora_settings = {
    'base_url': 'https://api.zuora.com/rest/v1/',
    'password': 'foo',
    'username': 'bar,
    'wsdl_file': 'zuora.prod.wsdl'
}
zuora_client = zuora.Zuora(zuora_settings)

zuora_client.rest_client.amendment.get_amendment_by_subscription_id('2c92a0fd57e07d490157e3889fxxxx')

{
 u'autoRenew': None,
 u'baseRatePlanId': u'2c92a0fe57594e6b0157678d230d3xxx,
 u'baseSubscriptionId': u'2c92a0fe57594e6b0157678d22exxxx',
 u'code': u'A-AM00021203',
 u'contractEffectiveDate': u'2016-09-09',
 u'currentTerm': None,
 u'currentTermPeriodType': None,
 u'customerAcceptanceDate': u'2016-09-09',
 u'description': u'Removed Product Plus Subscription, RatePlan Plus - Annual Billing - Event',
 u'destinationAccountId': None,
 u'destinationInvoiceOwnerId': None,
 u'effectiveDate': u'2016-09-09',
 u'id': u'2c92a0fe57594e6b0157678d236e3xxxx',
 u'name': u'POD 2016',
 u'newRatePlanId': u'2c92a0fe57594e6b0157678d23cexxxxx,
 u'newSubscriptionId': u'2c92a0fe57594e6b0157678d24xxxxx',
 u'renewalSetting': None,
 u'renewalTerm': None,
 u'renewalTermPeriodType': None,
 u'serviceActivationDate': u'2016-09-09',
 u'specificUpdateDate': None,
 u'status': u'Completed',
 u'success': True,
 u'termStartDate': None,
 u'termType': None,
 u'type': u'RemoveProduct'
}
```
