### PR TITLE
Add Subscription Versions API Interface 

### DIFF
--- a/zuora/rest_wrapper/subscription_manager.py
+++ b/zuora/rest_wrapper/subscription_manager.py
@@ -5,6 +5,7 @@ import logging
 log = logging.getLogger(__name__)
 
 from request_base import RequestBase, rest_client_reconnect
+from zuora.rest_wrapper.amendment_manager import AmendmentManager
 
 
 class SubscriptionManager(RequestBase):
@@ -75,3 +76,67 @@ class SubscriptionManager(RequestBase):
         response = requests.put(fullUrl, data=data,
                                 headers=self.zuora_config.headers)
         return self.get_json(response)
+
+
+    def get_each_subscription_version_and_all_mutating_amendments(self, subscription_key):
+        """
+        Returns a mixed list of subscriptions and amendments ordered by date.
+
+        Esssentially, this returns a list of sub + amendment dictionaries, starting
+        with the earliest version of the subscription and steps forward through
+        each amendment until we reach the most current version of the subscription.
+
+        The returned dict should look like:
+        [
+            {'type': 'subscritpion', 'subscritpion_id': '1'},
+            {'type': 'amendment', 'amendment_id': '1', 'changes': ...},
+            {'type': 'subscritpion', 'subscritpion_id': '2'},
+            {'type': 'amendment', 'amendment_id': '2', 'changes': ...},
+            {'type': 'subscritpion', 'subscritpion_id': '3'},
+        ]
+        """
+        subscription_and_amendment_list = []
+
+        # Fetch the most recent version of the subsription given a subscription key
+        subscription_response = self.get_subscriptions_by_key(subscription_key)
+
+        # Do not process unsuccessful responses
+        if not subscription_response.get('success', False):
+            raise Exception('Could not find a subscription for key: {}'.format(subscription_key))
+
+        # The way that Zuora's API is structured, it always returns the most recent
+        # version of a subscription first, then steps backwards through time
+        # to fetch amendments + subscription versions until reaches the original
+        # subscription version.
+        amendment_manager = AmendmentManager(self.zuora_config)
+        subscription_id = subscription_response.get('id')
+        has_valid_amendment = True
+        while has_valid_amendment:
+            subscription_response = self.get_subscriptions_by_key(subscription_id)
+
+            # Do not process unsuccessful responses
+            if not subscription_response.get('success', False):
+                raise Exception('Could not find a subscription for id: {}'.format(subscription_id))
+
+            # Append the subscription to the list of of subs + amendments
+            subscription_response.update({'obj_type': 'subscription'})
+            subscription_and_amendment_list.append(subscription_response)
+
+            # Get the amendment prior to this version of the subscription
+            amendment_response = amendment_manager.get_amendment_by_subscription_id(subscription_id)
+
+            # If one does not exist, then we have reached the original subscription
+            # should return the list of subscription versionss
+            if not amendment_response.get('success', False):
+                has_valid_amendment = False
+
+            # Append the amdment to the list of subs + amendments
+            amendment_response.update({'obj_type': 'amendment'})
+            subscription_and_amendment_list.append(amendment_response)
+
+            # Update the subscription_id (to fetch the next most recent version of the subscription)
+            subscription_id = amendment_response.get('baseSubscriptionId')
+
+        # Reverse the list of amendments + subs and return
+        subscription_and_amendment_list.reverse()
+        return subscription_and_amendment_list


### PR DESCRIPTION
## What
Adds an interface fetches each version of a single `Subscription` as well as each `Amendment` that caused each mutation . Zuora notes that its API only returns the most recent version of a subscription (given a subscription key like A-S00006503). That is insufficient if one wants to understand how `Subscriptions` change over time.

## Usage

``` python
import zuora

zuora_settings = {
    'base_url': 'https://api.zuora.com/rest/v1/',
    'password': 'foo',
    'username': 'bar,
    'wsdl_file': 'zuora.prod.wsdl'
}
zuora_client = zuora.Zuora(zuora_settings)

subscription_versions = zuora_client.rest_client.subscription.get_each_subscription_version_and_all_mutating_amendments(self, subscription_key)('A-S00006503')

[
  {"original subscription version"},
  {"amendment #1"},
  {"second subscription version"},
  {"amendment #2"},
  {"most recent subscription version"},
]
```
