### PR TITLE
Bump version number to `1.0.21`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 setupArgs = {
     'name': 'zuora',
-    'version': '1.0.20',
+    'version': '1.0.21',
     'author': 'MapMyFitness (Guidebook fork)',
     'author_email': 'naoya@guidebook.com',
     'url': 'http://github.com/naoyak/python-zuora',


### PR DESCRIPTION
## What
This should allow requiring packages for safely pip install upgrade to this newer version.

## Why
We've made a few new commits (see #8 and #9) to this branch, but pip won't upgrade to the new commit sha until the version number is bumped in `setup.py`.